### PR TITLE
Show image in map tooltip

### DIFF
--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -150,10 +150,14 @@ class DroneFieldGUI(tk.Tk):
             '''
             iframe = folium.IFrame(html=image_html, width=220, height=250)
             popup = folium.Popup(iframe, max_width=250)
+
+            tooltip_html = f'<img src="{entry["filename"]}" width="150">'
+            tooltip = folium.Tooltip(tooltip_html, parse_html=True)
+
             folium.Marker(
                 location=[entry["latitude"], entry["longitude"]],
                 popup=popup,
-                tooltip=entry["description"],
+                tooltip=tooltip,
             ).add_to(mymap)
 
         output_map = os.path.join(OUTPUT_DIR, "findings_map.html")


### PR DESCRIPTION
## Summary
- display extracted frame image in folium marker tooltip

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867ebb538608331abf4c3f874384f15