### PR TITLE
Change map marker color to brown

### DIFF
--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -178,6 +178,7 @@ class DroneFieldGUI(tk.Tk):
                 location=[entry["latitude"], entry["longitude"]],
                 popup=popup,
                 tooltip=tooltip,
+                icon=folium.Icon(color="brown"),
             ).add_to(mymap)
 
         self.add_flight_path(mymap)


### PR DESCRIPTION
## Summary
- make map markers brown so they stand out better

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'folium')*

------
https://chatgpt.com/codex/tasks/task_e_686976c80b208331ac400d346156162f