### PR TITLE
Unify results in DataFrame

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -107,3 +107,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+
+-------------------------------------------------------
+pandas
+License: BSD 3-Clause "New" or "Revised" License
+Homepage: https://pandas.pydata.org/
+-------------------------------------------------------
+
+BSD 3-Clause License
+
+Copyright (c) 2008-2024, The pandas development team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the pandas development team nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ python main.py
 - [pysrt](https://github.com/byroot/pysrt) - Parses subtitle files containing GPS coordinates.
 - [Pillow](https://python-pillow.org/) - Image loading and thumbnail generation.
 - [Folium](https://github.com/python-visualization/folium) - Renders the interactive map with popups.
+- [pandas](https://pandas.pydata.org/) - Stores extraction and detection results in a single DataFrame.
+
+### Acknowledgments
+This project uses the Pandas library, © The Pandas Development Team, licensed under the BSD 3-Clause License.

--- a/drone_field_analysis/utils/data_processing.py
+++ b/drone_field_analysis/utils/data_processing.py
@@ -16,9 +16,12 @@ def encode_image(image_path: str) -> str:
 
 
 def report_bare_spot(location: str, confidence: float) -> str:
-    """Print and return a short report about a detected bare spot."""
-    message = f"✅ Found a bare spot at {location} with confidence {confidence:.2f}"
-    print(message)
+    """Return a two sentence description of a detected bare spot."""
+    message = (
+        f"A bare spot was detected at {location}. "
+        f"Detection confidence is {confidence:.2f}."
+    )
+    print(f"✅ {message}")
     return message
 
 
@@ -33,8 +36,10 @@ def analyze_frame(image_path: str):
     Returns
     -------
     dict | None
-        Dictionary with location, confidence and report message if a bare
-        spot was detected with high confidence, otherwise ``None``.
+        Dictionary describing the bare spot if one is detected with high
+        confidence. The dictionary contains ``object_type``, ``location``,
+        ``description``, ``confidence`` and ``bbox`` keys. If no bare spot is
+        found ``None`` is returned.
     """
     base64_image = encode_image(image_path)
     response = client.chat.completions.create(
@@ -101,9 +106,11 @@ def analyze_frame(image_path: str):
                 if args.get("confidence", 0) >= 0.85:
                     report = report_bare_spot(args["location"], args["confidence"])
                     return {
+                        "object_type": "bare spot",
                         "location": args["location"],
                         "confidence": args["confidence"],
-                        "report": report,
+                        "description": report,
+                        "bbox": None,
                     }
     return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ opencv-python>=4.9
 pysrt>=1.1
 Pillow>=10.0
 folium>=0.15
+pandas>=2.1


### PR DESCRIPTION
## Summary
- output frames to a pandas DataFrame instead of a dictionary
- store detection results in the same DataFrame
- update GUI to display frames from DataFrame
- enhance descriptions and return object type from analysis
- document pandas dependency
- add Pandas license and attribution

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686998efe164833180b7600b600537f9