### PR TITLE
Add GPS visibility toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ python main.py
 3. Click **Browse** beside *SRT File* and choose the matching subtitle file containing GPS data.
 4. Press **Scan** to extract frames and analyze each one for bare spots.
 5. Detected spots appear in the **Found Elements** list as image thumbnails.
-6. Click any thumbnail to view the full image with its GPS coordinates and raw
-   GPS text.
+6. Click any thumbnail to view the full image. Use the *Show Raw GPS Data*
+   checkbox to display or hide the frame's GPS coordinates and the subtitle's
+   raw GPS text.
 7. When scanning finishes, press **Show on Map** to open a browser displaying all detections. Enable *Show Flight Path* to visualize the drone's route.
 
 ## Features

--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -3,7 +3,7 @@
 import logging
 import tkinter as tk
 
-from tkinter import filedialog, messagebox
+from tkinter import filedialog, messagebox, ttk
 from typing import cast
 import os
 import webbrowser
@@ -114,12 +114,24 @@ class DroneFieldGUI(tk.Tk):
         )
         self.show_map_button.grid(row=7, column=0, columnspan=3, pady=10)
 
+        # Separator line above utility options
+        ttk.Separator(self, orient="horizontal").grid(
+            row=8, column=0, columnspan=3, sticky="ew", pady=(0, 5)
+        )
+
         self.show_path_var = tk.BooleanVar(value=True)
         tk.Checkbutton(
             self,
             text="Show Flight Path",
             variable=self.show_path_var,
-        ).grid(row=8, column=0, columnspan=3)
+        ).grid(row=9, column=0, columnspan=3)
+
+        self.show_gps_var = tk.BooleanVar(value=True)
+        tk.Checkbutton(
+            self,
+            text="Show Raw GPS Data",
+            variable=self.show_gps_var,
+        ).grid(row=10, column=0, columnspan=3)
 
     def browse_mp4(self):
         """Prompt the user to select an MP4 file."""
@@ -153,7 +165,9 @@ class DroneFieldGUI(tk.Tk):
         lat, lon:
             GPS coordinates associated with the frame.
         gps_text:
-            Raw GPS text from the subtitle track.
+            Raw GPS text from the subtitle track. Display of the GPS
+            coordinates and this value can be toggled using the
+            *Show Raw GPS Data* option in the main window.
         """
         top = tk.Toplevel(self)
         top.title("Image Viewer")
@@ -167,9 +181,11 @@ class DroneFieldGUI(tk.Tk):
         img_label.pack()
 
         clean_desc = self._clean_description(description)
-        info_lines = [f"Lat: {lat}", f"Lon: {lon}"]
-        if gps_text:
-            info_lines.append(f"GPS: {gps_text}")
+        info_lines = []
+        if self.show_gps_var.get():
+            info_lines.extend([f"Lat: {lat}", f"Lon: {lon}"])
+            if gps_text:
+                info_lines.append(f"GPS: {gps_text}")
         info_lines.append(clean_desc)
         info = "\n".join(info_lines)
         tk.Label(top, text=info, font=("Arial", 12)).pack(pady=10)


### PR DESCRIPTION
## Summary
- add a `Show Raw GPS Data` checkbox in the GUI
- gate all GPS info in the full image viewer behind this setting
- add a separator line before the utility checkboxes
- clarify GPS visibility option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bce8962d083318e2d792a69ca11af