### PR TITLE
Add dropdown for object type and support animal detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Place your `.mp4` video and matching `.srt` file into the `footage/` folder befo
 The `drone_field_analysis/utils/data_processing.py` module demonstrates how to analyze the extracted frames using
 the OpenAI API. A frame is sent to the `gpt-4o` model with instructions to look
 for large, clearly visible bare soil patches. If the model detects such a bare
-spot with high confidence it triggers the `report_bare_spot` function, printing
+spot with high confidence it triggers the `report_object` function, printing
 the estimated location and confidence score.
 
 Set the `OPENAI_API_KEY` environment variable before running this script.


### PR DESCRIPTION
## Summary
- add option in the GUI to choose what objects to detect
- rename `report_bare_spot` to `report_object`
- support both bare spot and animal detection using one OpenAI prompt helper
- pass selected object type from the GUI to analysis
- update README for renamed function

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d3509b19c83319f97936d70ffeeaf