### PR TITLE
Add generic detect_object helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Place your `.mp4` video and matching `.srt` file into the `footage/` folder befo
 The `drone_field_analysis/utils/data_processing.py` module demonstrates how to analyze the extracted frames using
 the OpenAI API. A frame is sent to the `gpt-4o` model with instructions to look
 for large, clearly visible bare soil patches. If the model detects such a bare
-spot with high confidence it triggers the `report_bare_spot` function, printing
+spot with high confidence it triggers the `detect_object` function, printing
 the estimated location and confidence score.
 
 Set the `OPENAI_API_KEY` environment variable before running this script.

--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -30,6 +30,7 @@ class DroneFieldGUI(tk.Tk):
         self.title("Drone Field Analyzer")
         self.mp4_path = tk.StringVar()
         self.srt_path = tk.StringVar()
+        self.search_for = tk.StringVar(value="Bare spots")
         # Store metadata and detection results for each extracted frame
         self.data = pd.DataFrame(
             columns=[
@@ -80,6 +81,17 @@ class DroneFieldGUI(tk.Tk):
         tk.Button(self, text="Browse", command=self.browse_srt).grid(
             row=2, column=2, padx=5, pady=5
         )
+
+        tk.Label(self, text="Look For:").grid(
+            row=3, column=0, sticky="e", padx=5, pady=5
+        )
+        tk.OptionMenu(
+            self,
+            self.search_for,
+            "Bare spots",
+            "Animals",
+            "Bare spots and animals",
+        ).grid(row=3, column=1, columnspan=2, padx=5, pady=5, sticky="w")
         tk.Button(self, text="Scan", command=self.scan).grid(
             row=4, column=0, columnspan=3, pady=10
         )
@@ -289,7 +301,7 @@ class DroneFieldGUI(tk.Tk):
                 ).add_to(mymap)
 
     def scan(self):
-        """Run frame extraction and bare spot detection."""
+        """Run frame extraction and object detection based on user choice."""
         mp4 = self.mp4_path.get()
         srt = self.srt_path.get()
         if not mp4 or not srt:
@@ -306,7 +318,7 @@ class DroneFieldGUI(tk.Tk):
         try:
             self.data = extract_frames_with_gps(mp4, srt, output_dir)
             for idx, row in self.data.iterrows():
-                result = analyze_frame(row["image_path"])
+                result = analyze_frame(row["image_path"], self.search_for.get())
                 if result:
                     self.data.at[idx, "object_type"] = result["object_type"]
                     self.data.at[idx, "report"] = result["report"]

--- a/drone_field_analysis/utils/data_processing.py
+++ b/drone_field_analysis/utils/data_processing.py
@@ -1,4 +1,4 @@
-"""Bare spot detection routines using the OpenAI API."""
+"""Object detection routines using the OpenAI API."""
 
 import base64
 import json
@@ -23,61 +23,118 @@ def encode_image(image_path: str) -> str:
         return base64.b64encode(image_file.read()).decode("utf-8")
 
 
-def report_bare_spot(report: str, confidence: float, box_parameter: str) -> str:
-    """Return a short description of a detected bare spot.
+def detect_object(
+    object_type: str, report: str, confidence: float, box_parameter: str
+) -> dict:
+    """Return a standardized result description for a detected object."""
 
-    This function mirrors the schema expected by the OpenAI function calling
-    API. It is invoked by the language model when a bare spot is found with
-    sufficient confidence.
-    """
     message = (
+        f"Object: {object_type} \n"
         f"Report: {report} \n"
         f"Detection confidence is {confidence:.2f}. \n"
         f"Box coordinates: {box_parameter}."
     )
-    logger.info("\N{microscope} %s", message)
-    return message
+    logger.info("\N{satellite} %s", message)
+    return {
+        "object_type": object_type,
+        "report": report,
+        "confidence": confidence,
+        "box_parameter": box_parameter,
+        "description": message,
+    }
 
 
-def analyze_frame(image_path: str):
-    """Analyze a frame for bare spots using the OpenAI API.
+def _build_result(args: dict) -> dict | None:
+    """Return a standardized result dictionary for a tool call."""
+
+    if args.get("confidence", 0) < 0.85:
+        return None
+
+    return detect_object(
+        args.get("object_type", "unknown"),
+        args.get("report", ""),
+        args["confidence"],
+        str(args.get("box_parameter")),
+    )
+
+
+def analyze_frame(image_path: str, look_for: str) -> dict | None:
+    """Analyze a frame using the OpenAI API for the selected objects.
 
     Parameters
     ----------
     image_path: str
         Path to the frame image.
+    look_for: str
+        Text describing the objects to search for (e.g. "bare spot", "animal").
 
     Returns
     -------
     dict | None
-        Dictionary describing the bare spot if one is detected with high
-        confidence. The dictionary contains ``object_type``, ``location``,
-        ``description``, ``confidence`` and ``box_parameter`` keys. If no bare
-        spot is found ``None`` is returned.
+        Dictionary describing a detected object if one is found with high
+        confidence. The dictionary contains ``object_type``, ``report``,
+        ``description``, ``confidence`` and ``box_parameter`` keys. ``None`` is
+        returned if no relevant object is detected.
     """
-    # Convert the frame to a base64 string and send it to the vision model
     base64_image = encode_image(image_path)
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "detect_object",
+                "description": "Function to report detected objects",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "object_type": {"type": "string"},
+                        "report": {"type": "string"},
+                        "confidence": {"type": "number"},
+                        "box_parameter": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                        },
+                    },
+                    "required": ["object_type", "report", "confidence", "box_parameter"],
+                },
+            },
+        }
+    ]
+
+    prompt_parts = ["Analyze this frame and identify any of the following objects:"]
+
+    if "bare spot" in look_for.lower():
+        prompt_parts.append(
+            "- **Bare spots**: Analyze this frame of the field and identify any bare spots. "
+            "A bare spot is defined as a **large, clearly visible patch of exposed soil** "
+            "with **no visible crop growth**, not just a small gap between plants. "
+            "These areas often appear as dark, compacted zones, paths, or spots, "
+            "possibly caused by machinery, drought, or compaction. "
+            "**Only call the `detect_object` function if the bare soil area "
+            "is large and clearly distinct from healthy crop rows.** "
+            "Describe the bare spot in 1 sentence (e.g. are there cracks in the soil, "
+            "is there a water deficit). "
+            "Return the box coordinates of the spot as [x1, y1, x2, y2] for a 1920x1080 image."
+        )
+
+    if "animal" in look_for.lower():
+        prompt_parts.append(
+            "- **Animals**: clearly visible animals like deer, birds, or rabbits, and nests of egg-laying animals."
+        )
+
+    prompt_parts.append(
+        "Return results using the `detect_object` function and include bounding box [x1, y1, x2, y2] using 1920x1080 coordinates."
+    )
+
+    prompt_text = "\n".join(prompt_parts)
+
     response = client.chat.completions.create(
         model="gpt-4o",
         messages=[
             {
                 "role": "user",
                 "content": [
-                    {
-                        "type": "text",
-                        "text": (
-                            "Analyze this frame of the field and identify any bare spots. "
-                            "A bare spot is defined as a **large, clearly visible patch of exposed soil** "
-                            "with **no visible crop growth**, not just a small gap between plants. "
-                            "These areas often appear as dark, compacted zones, paths, or spots, "
-                            "possibly caused by machinery, drought, or compaction. "
-                            "**Only call the `report_bare_spot` function if the bare soil area "
-                            "is large and clearly distinct from healthy crop rows.** "
-                            "Describe the bare spot in 1 sentence (e.g. are there cracks in the soil, "
-                            "is there a water deficit). "
-                            "Return the box coordinates of the spot as [x1, y1, x2, y2] for a 1920x1080 image."
-                        ),
-                    },
+                    {"type": "text", "text": prompt_text},
                     {
                         "type": "image_url",
                         "image_url": {
@@ -88,64 +145,26 @@ def analyze_frame(image_path: str):
                 ],
             }
         ],
-        tools=[
-            {
-                "type": "function",
-                "function": {
-                    "name": "report_bare_spot",
-                    "description": "Funktion to report found bare spots",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "report": {
-                                "type": "string",
-                                "description": "Describe the bare spot in 1 Sentence e.g are there cracks in the soil, is there a water deficit",
-                            },
-                            "confidence": {
-                                "type": "number",
-                                "description": "Confidence level from 0 to 1",
-                            },
-                            "box_parameter": {
-                                "type": "array",
-                                "items": {"type": "integer"},
-                                "description": "Bounding box [x1, y1, x2, y2] using 1920x1080 image coordinates",
-                            },
-                        },
-                        "required": ["report", "confidence", "box_parameter"],
-                    },
-                },
-            }
-        ],
+        tools=tools,
         tool_choice="auto",
-        max_tokens=100,
+        max_tokens=200,
     )
 
-    # The model may decide to call ``report_bare_spot`` with its findings
+    results = []
     tool_calls = response.choices[0].message.tool_calls
     if tool_calls:
-        # Iterate over any function calls returned by the model
         for tool_call in tool_calls:
-            if tool_call.function.name == "report_bare_spot":
-                args = json.loads(tool_call.function.arguments)
-                # Only accept detections with reasonably high confidence
-                if args.get("confidence", 0) >= 0.85:
-                    report = report_bare_spot(
-                        args["report"],
-                        args["confidence"],
-                        str(args.get("box_parameter")),
-                    )
-                    return {
-                        # Information stored back into the DataFrame
-                        "object_type": "bare spot",
-                        "report": args["report"],
-                        "confidence": args["confidence"],
-                        "description": report,
-                        "box_parameter": args.get("box_parameter"),
-                    }
-    return None
+            if tool_call.function.name != "detect_object":
+                continue
+            args = json.loads(tool_call.function.arguments)
+            result = _build_result(args)
+            if result:
+                results.append(result)
+
+    return results[0] if results else None
 
 
 if __name__ == "__main__":
     # Simple manual test when running this file directly
     sample_path = os.path.join(OUTPUT_DIR, "frame_013.jpg")
-    analyze_frame(sample_path)
+    analyze_frame(sample_path, "bare spot")


### PR DESCRIPTION
## Summary
- refactor detection utilities to use a single `detect_object` function
- build OpenAI prompt using `detect_object` for both bare spots and animals
- update prompt to also search for nests of egg-laying animals
- refresh README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d3acfafd083318bb829ef92da3316