### PR TITLE
Improve map popup layout

### DIFF
--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -263,10 +263,12 @@ class DroneFieldGUI(tk.Tk):
                 img_base64 = ""
 
             # 🖼️ Create HTML content with base64 image embedded
+            title = entry.get("object_type", "")
             report_text = entry.get("report", "")
             image_html = f"""
                 <div>
-                    <strong>{report_text}</strong><br>
+                    <strong>{title}</strong><br>
+                    {report_text}<br>
                     <img src="data:image/jpeg;base64,{img_base64}" width="200">
                 </div>
             """


### PR DESCRIPTION
## Summary
- change popup to show detection type as the title
- display the report text below the title in the map popup

## Testing
- `pytest -q`
- `python -m py_compile drone_field_analysis/gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_686edc39d28c833185d0966a8ba66bbf