### PR TITLE
Support custom object search

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The GUI presents a scrollable list of all findings. Clicking a thumbnail opens t
 ## Input files
 Place your `.mp4` video and matching `.srt` file into the `footage/` folder before running the analysis.
 
+To search for a specific object, edit `drone_field_analysis/config/search_target.txt`
+and enter the item you want the model to look for. Choose **Custom (file)** in
+the *Look For* menu to use this value during scanning.
+
 ## AI bare spot and animal detection
 
 The `drone_field_analysis/utils/data_processing.py` module demonstrates how to analyze the extracted frames using

--- a/drone_field_analysis/config/search_target.txt
+++ b/drone_field_analysis/config/search_target.txt
@@ -1,0 +1,2 @@
+# Enter the object you want the analysis to look for.
+bare spot

--- a/drone_field_analysis/config/settings.py
+++ b/drone_field_analysis/config/settings.py
@@ -1,5 +1,10 @@
 """Configuration settings for Drone Field Analysis."""
 
+import os
+
 # Folder to store extracted frames and analysis results
 # This directory will be created automatically if it does not exist.
 OUTPUT_DIR = "output"
+
+# Text file containing the object(s) the user wants to search for
+SEARCH_TARGET_FILE = os.path.join(os.path.dirname(__file__), "search_target.txt")


### PR DESCRIPTION
## Summary
- allow specifying custom object via `config/search_target.txt`
- read the custom target in the GUI and analysis module
- adjust prompts and parsing to handle custom objects
- document the feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687538eeb1c483318ad4dd853fee773b