### PR TITLE
Implement CSV export and white logging

### DIFF
--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -359,7 +359,13 @@ class DroneFieldGUI(tk.Tk):
                         boxed_path = row["image_path"]
                 self.data.at[idx, "boxed_image_path"] = boxed_path
                 self.add_finding(self.data.loc[idx])
-            messagebox.showinfo("Scan Complete", f"Frames saved to '{output_dir}'")
+            # Persist all collected data for later review
+            csv_path = os.path.join(output_dir, "results.csv")
+            self.data.to_csv(csv_path, index=False)
+            messagebox.showinfo(
+                "Scan Complete",
+                f"Frames saved to '{output_dir}'. Results written to '{csv_path}'",
+            )
             if self.show_map_button:
                 # Enable map button once processing is finished
                 self.show_map_button.config(state="normal")

--- a/drone_field_analysis/utils/logging_utils.py
+++ b/drone_field_analysis/utils/logging_utils.py
@@ -6,10 +6,15 @@ both the GUI and command-line scripts to ensure consistent log formatting.
 """
 
 import logging
+import sys
 from typing import Optional
 
 
-def configure_logging(level: int = logging.INFO, log_format: Optional[str] = None) -> None:
+def configure_logging(
+    level: int = logging.INFO,
+    log_format: Optional[str] = None,
+    log_file: str = "log.txt",
+) -> None:
     """Configure basic logging for the application.
 
     Parameters
@@ -25,5 +30,16 @@ def configure_logging(level: int = logging.INFO, log_format: Optional[str] = Non
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
     # ``basicConfig`` should only be called once across the application.
-    logging.basicConfig(level=level, format=log_format)
+    white = "\033[97m"
+    reset = "\033[0m"
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(
+        logging.Formatter(f"{white}{log_format}{reset}")
+    )
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(logging.Formatter(log_format))
+
+    logging.basicConfig(level=level, handlers=[stream_handler, file_handler])
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def main() -> None:
     This function merely sets up logging and instantiates the GUI class.
     """
     # Configure the root logger before any other modules create loggers
-    configure_logging()
+    configure_logging(log_file="log.txt")
 
     # Instantiate the window and start Tkinter's event loop which blocks
     # until the user exits the program


### PR DESCRIPTION
## Summary
- send logs to a `log.txt` file and print them in white text
- save scan results to `results.csv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877ecb825588331a2eedb929ff42dba