### PR TITLE
Remove 'Both' scan option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ python main.py
 1. Launch the program with the command above. The main window opens.
 2. Click **Browse** beside *MP4 File* and select your drone video.
 3. Click **Browse** beside *SRT File* and choose the matching subtitle file containing GPS data.
-4. Choose whether to search for *Bare spots*, *Animals* or *Both* and press **Scan** to analyze each extracted frame.
+4. Choose whether to search for *Bare spots* or *Animals* and press **Scan** to analyze each extracted frame.
 5. Detected spots appear in the results list as image thumbnails.
 6. Click any thumbnail to view the full image with its GPS coordinates. The subtitle's raw GPS
    information is displayed automatically when available.

--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -88,9 +88,9 @@ class DroneFieldGUI(tk.Tk):
             row=3, column=0, sticky="e", padx=5, pady=5
         )
         # The option menu allows users to specify what objects should be
-        # detected in each frame. Choices are bare spots, animals or both.
+        # detected in each frame. Choices are bare spots or animals.
         self.look_for_var = tk.StringVar(value="Bare spots")
-        options = ["Bare spots", "Animals", "Both"]
+        options = ["Bare spots", "Animals"]
         tk.OptionMenu(self, self.look_for_var, *options).grid(
             row=3, column=1, columnspan=2, sticky="w", padx=5, pady=5
         )


### PR DESCRIPTION
## Summary
- drop "Both" choice for scans
- document updated options in the README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687bad074d208331a294a87ee9690133