### PR TITLE
Change progress label color to white

### DIFF
--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -139,7 +139,7 @@ class DroneFieldGUI(tk.Tk):
         # Use a distinct foreground color so the text remains visible even on
         # dark themes.
         self.progress_label = tk.Label(
-            self, textvariable=self.progress_var, fg="blue"
+            self, textvariable=self.progress_var, fg="white"
         )
         self.progress_label.grid(row=8, column=0, columnspan=3, pady=(0, 10))
 


### PR DESCRIPTION
## Summary
- adjust progress label color so it displays white text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687bb01b691c8331be3433bc9a8719f2