### PR TITLE
Align Clear Output button with scan and map controls

### DIFF
--- a/drone_field_analysis/gui/main_window.py
+++ b/drone_field_analysis/gui/main_window.py
@@ -95,9 +95,9 @@ class DroneFieldGUI(tk.Tk):
         tk.OptionMenu(self, self.look_for_var, *options).grid(
             row=3, column=1, columnspan=2, sticky="w", padx=5, pady=5
         )
-        # Action buttons are placed at the bottom of the window. The Scan button
-        # sits to the left of the "Show on Map" button so users can easily start
-        # a scan and then display the results.
+        # Action buttons are placed at the bottom of the window. The Scan,
+        # Show on Map and Clear Output buttons share the same row so users can
+        # quickly start a scan, view the map and remove old results.
         self.scan_button = tk.Button(self, text="Scan", command=self.scan)
         self.scan_button.grid(row=6, column=0, pady=10, padx=(10, 5))
         self.results_canvas = tk.Canvas(self, width=400, height=200)
@@ -128,7 +128,7 @@ class DroneFieldGUI(tk.Tk):
             command=self.show_map,
             state="disabled",
         )
-        self.show_map_button.grid(row=6, column=1, columnspan=2, pady=10, padx=(5, 10))
+        self.show_map_button.grid(row=6, column=1, pady=10, padx=5)
 
         # Toggle whether the flight path polyline is drawn on the map
         self.show_path_var = tk.BooleanVar(value=True)
@@ -146,7 +146,7 @@ class DroneFieldGUI(tk.Tk):
             self,
             text="Clear Output",
             command=self.clear_output,
-        ).grid(row=9, column=0, columnspan=3, pady=(0, 10))
+        ).grid(row=6, column=2, pady=10, padx=(5, 10))
 
     def browse_mp4(self):
         """Prompt the user to select an MP4 file."""


### PR DESCRIPTION
## Summary
- place the Clear Output button on the same row as the Scan and Show Map buttons
- update layout comment

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e4f052508331a7aa16bdf1361ed7