### PR TITLE
Refactor frame analysis using strategy pattern

### DIFF
--- a/drone_field_analysis/utils/analyzers.py
+++ b/drone_field_analysis/utils/analyzers.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+"""Analyzers used by :mod:`data_processing`.
+
+This module implements a small strategy/factory setup for describing
+objects that can be detected in a frame. Each analyzer exposes the
+schema for the OpenAI function calling API and knows how to interpret the
+model's response. The design follows the Strategy pattern where each
+concrete analyzer encapsulates the behaviour for a single object type.
+"""
+
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def report_bare_spot(report: str, confidence: float, box_parameter: str) -> str:
+    """Return a short description of a detected bare spot."""
+    message = (
+        f"Report: {report} \n"
+        f"Detection confidence is {confidence:.2f}. \n"
+        f"Box coordinates: {box_parameter}."
+    )
+    logger.info("\N{microscope} %s", message)
+    return message
+
+
+def report_animal(
+    species: str, description: str, confidence: float, box_parameter: str
+) -> str:
+    """Return a short description of a detected animal."""
+    message = (
+        f"Species: {species} \n"
+        f"Description: {description} \n"
+        f"Detection confidence is {confidence:.2f}. \n"
+        f"Box coordinates: {box_parameter}."
+    )
+    logger.info("\N{dog} %s", message)
+    return message
+
+
+def report_weed(report: str, confidence: float, box_parameter: str) -> str:
+    """Return a short description of detected weeds."""
+    message = (
+        f"Report: {report} \n"
+        f"Detection confidence is {confidence:.2f}. \n"
+        f"Box coordinates: {box_parameter}."
+    )
+    logger.info("\N{herb} %s", message)
+    return message
+
+
+@dataclass
+class Analyzer(ABC):
+    """Base class for all analyzers."""
+
+    object_type: str
+
+    @property
+    @abstractmethod
+    def function_name(self) -> str:
+        """Name used in the OpenAI tool definition."""
+
+    @property
+    @abstractmethod
+    def tool(self) -> Dict[str, Any]:
+        """Return the tool schema for the OpenAI API."""
+
+    @property
+    @abstractmethod
+    def prompt(self) -> str:
+        """Prompt segment describing this object type."""
+
+    @abstractmethod
+    def parse(self, args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Convert tool call arguments into a result dictionary."""
+
+
+class BareSpotAnalyzer(Analyzer):
+    object_type = "bare spot"
+    function_name = "report_bare_spot"
+    tool = {
+        "type": "function",
+        "function": {
+            "name": function_name,
+            "description": "Function to report bare spots in the field",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "report": {"type": "string"},
+                    "confidence": {"type": "number"},
+                    "box_parameter": {"type": "array", "items": {"type": "integer"}},
+                },
+                "required": ["report", "confidence", "box_parameter"],
+            },
+        },
+    }
+    prompt = (
+        "- **Bare spots**: Bare spots: Large, clearly visible patches of exposed soil with no "
+        "signs of crop growth. These areas appear as uncovered earth — typically light brown or "
+        "tan — with no green vegetation, leaves, or canopy overhead. A valid bare spot must be at "
+        "least 5x5 cm in real-world size, fully free from crops, shadow, debris, or partial "
+        "coverage. The soil surface should be unobstructed and distinctly visible from above."
+    )
+
+    def parse(self, args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if args.get("confidence", 0) < 0.85:
+            return None
+        return {
+            "object_type": self.object_type,
+            "report": args["report"],
+            "confidence": args["confidence"],
+            "box_parameter": args.get("box_parameter"),
+            "description": report_bare_spot(
+                args["report"], args["confidence"], str(args.get("box_parameter"))
+            ),
+        }
+
+
+class AnimalAnalyzer(Analyzer):
+    object_type = "animal"
+    function_name = "report_animal"
+    tool = {
+        "type": "function",
+        "function": {
+            "name": function_name,
+            "description": "Function to report detected animals in the field",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "species": {"type": "string"},
+                    "description": {"type": "string"},
+                    "confidence": {"type": "number"},
+                    "box_parameter": {"type": "array", "items": {"type": "integer"}},
+                },
+                "required": ["species", "description", "confidence", "box_parameter"],
+            },
+        },
+    }
+    prompt = "- **Animals**: clearly visible animals like deer, birds, or rabbits."
+
+    def parse(self, args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if args.get("confidence", 0) < 0.85:
+            return None
+        return {
+            "object_type": self.object_type,
+            "species": args["species"],
+            "description": args["description"],
+            "confidence": args["confidence"],
+            "box_parameter": args.get("box_parameter"),
+        }
+
+
+class WeedAnalyzer(Analyzer):
+    object_type = "weed"
+    function_name = "report_weed"
+    tool = {
+        "type": "function",
+        "function": {
+            "name": function_name,
+            "description": "Function to report weeds in the field",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "report": {"type": "string"},
+                    "confidence": {"type": "number"},
+                    "box_parameter": {"type": "array", "items": {"type": "integer"}},
+                },
+                "required": ["report", "confidence", "box_parameter"],
+            },
+        },
+    }
+    prompt = (
+        "- **Weeds**: Detect the presence of weeds in this image. Weeds are characterized by small "
+        "or clustered patches of green vegetation that visually contrast with the golden or beige "
+        "wheat crop. Focus on: Green plant patches that are structurally or color-wise different "
+        "from the wheat Vegetation in areas of exposed soil or near crop gaps Ignore: Dark soil "
+        "patches without green coloration Shadows or flattened wheat that may appear darker but "
+        "match wheat color/texture Dry/dead plant matter with no distinct green tones"
+    )
+
+    def parse(self, args: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if args.get("confidence", 0) < 0.85:
+            return None
+        return {
+            "object_type": self.object_type,
+            "report": args["report"],
+            "confidence": args["confidence"],
+            "box_parameter": args.get("box_parameter"),
+            "description": report_weed(
+                args["report"], args["confidence"], str(args.get("box_parameter"))
+            ),
+        }
+
+
+class AnalyzerFactory:
+    """Factory for creating analyzers based on the ``look_for`` value."""
+
+    _registry = {
+        "bare": BareSpotAnalyzer,
+        "animal": AnimalAnalyzer,
+        "weed": WeedAnalyzer,
+    }
+
+    @classmethod
+    def create(cls, look_for: str) -> List[Analyzer]:
+        """Return analyzers matching the ``look_for`` string."""
+        look_for = look_for.lower()
+        analyzers: List[Analyzer] = []
+        for key, analyzer_cls in cls._registry.items():
+            if key in look_for:
+                analyzers.append(analyzer_cls())
+        return analyzers

--- a/drone_field_analysis/utils/data_processing.py
+++ b/drone_field_analysis/utils/data_processing.py
@@ -12,6 +12,7 @@ import os
 from openai import OpenAI
 
 from ..config.settings import OUTPUT_DIR
+from .analyzers import AnalyzerFactory
 
 
 logger = logging.getLogger(__name__)
@@ -27,48 +28,6 @@ def encode_image(image_path: str) -> str:
     """
     with open(image_path, "rb") as image_file:
         return base64.b64encode(image_file.read()).decode("utf-8")
-
-
-def report_bare_spot(report: str, confidence: float, box_parameter: str) -> str:
-    """Return a short description of a detected bare spot.
-
-    This function mirrors the schema expected by the OpenAI function calling
-    API. It is invoked by the language model when a bare spot is found with
-    sufficient confidence.
-    """
-    message = (
-        f"Report: {report} \n"
-        f"Detection confidence is {confidence:.2f}. \n"
-        f"Box coordinates: {box_parameter}."
-    )
-    logger.info("\N{microscope} %s", message)
-    return message
-
-
-def report_animal(
-    species: str, description: str, confidence: float, box_parameter: str
-) -> str:
-    """Return a short description of a detected animal."""
-    message = (
-        f"Species: {species} \n"
-        f"Description: {description} \n"
-        f"Detection confidence is {confidence:.2f}. \n"
-        f"Box coordinates: {box_parameter}."
-    )
-    logger.info("\N{dog} %s", message)
-    return message
-
-
-def report_weed(report: str, confidence: float, box_parameter: str) -> str:
-    """Return a short description of detected weeds."""
-
-    message = (
-        f"Report: {report} \n"
-        f"Detection confidence is {confidence:.2f}. \n"
-        f"Box coordinates: {box_parameter}."
-    )
-    logger.info("\N{herb} %s", message)
-    return message
 
 
 def analyze_frame(image_path: str, look_for: str = "bare spot"):
@@ -88,94 +47,24 @@ def analyze_frame(image_path: str, look_for: str = "bare spot"):
     """
     base64_image = encode_image(image_path)
 
-    tools = []  # functions exposed to the language model for structured output
+    analyzers = AnalyzerFactory.create(look_for)
+    if not analyzers:
+        return None
+
+    tools = [analyzer.tool for analyzer in analyzers]
     prompt_parts = [
-        "Analyze this frame and identify any of the following objects:"
-    ]  # Text instructions passed to the model
-
-    if "bare spot" in look_for.lower():
-        # Allow the model to call ``report_bare_spot`` when a patch of bare soil
-        # is detected in the frame
-        tools.append(
-            {
-                "type": "function",
-                "function": {
-                    "name": "report_bare_spot",
-                    "description": "Function to report bare spots in the field",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "report": {"type": "string"},
-                            "confidence": {"type": "number"},
-                            "box_parameter": {"type": "array", "items": {"type": "integer"}},
-                        },
-                        "required": ["report", "confidence", "box_parameter"],
-                    },
-                },
-            }
-        )
-        prompt_parts.append(
-            "- **Bare spots**: Bare spots: Large, clearly visible patches of exposed soil with no signs of crop growth. These areas appear as uncovered earth — typically light brown or tan — with no green vegetation, leaves, or canopy overhead. A valid bare spot must be at least 5x5 cm in real-world size, fully free from crops, shadow, debris, or partial coverage. The soil surface should be unobstructed and distinctly visible from above."
-        )
-
-    if "animal" in look_for.lower():
-        # Similarly expose ``report_animal`` for animal sightings
-        tools.append(
-            {
-                "type": "function",
-                "function": {
-                    "name": "report_animal",
-                    "description": "Function to report detected animals in the field",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "species": {"type": "string"},
-                            "description": {"type": "string"},
-                            "confidence": {"type": "number"},
-                            "box_parameter": {"type": "array", "items": {"type": "integer"}},
-                        },
-                        "required": ["species", "description", "confidence", "box_parameter"],
-                    },
-                },
-            }
-        )
-        prompt_parts.append(
-            "- **Animals**: clearly visible animals like deer, birds, or rabbits."
-        )
-
-    if "weed" in look_for.lower():
-        tools.append(
-            {
-                "type": "function",
-                "function": {
-                    "name": "report_weed",
-                    "description": "Function to report weeds in the field",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "report": {"type": "string"},
-                            "confidence": {"type": "number"},
-                            "box_parameter": {"type": "array", "items": {"type": "integer"}},
-                        },
-                        "required": ["report", "confidence", "box_parameter"],
-                    },
-                },
-            }
-        )
-        prompt_parts.append(
-            "- **Weeds**: Detect the presence of weeds in this image. Weeds are characterized by small or clustered patches of green vegetation that visually contrast with the golden or beige wheat crop. Focus on: Green plant patches that are structurally or color-wise different from the wheat Vegetation in areas of exposed soil or near crop gaps Ignore: Dark soil patches without green coloration Shadows or flattened wheat that may appear darker but match wheat color/texture Dry/dead plant matter with no distinct green tones"
-        )
-
+        "Analyze this frame and identify any of the following objects:",
+    ]
+    prompt_parts.extend(analyzer.prompt for analyzer in analyzers)
     prompt_parts.append(
-        "Return results by calling the appropriate function and always include the bounding box as [x1, y1, x2, y2]. Ensure the entire object is fully contained within the box. If multiple objects of the same type are present, draw a single box that tightly encloses all of them. Do not include any unrelated areas or background in the bounding box."
+        "Return results by calling the appropriate function and always include "
+        "the bounding box as [x1, y1, x2, y2]. Ensure the entire object is fully "
+        "contained within the box. If multiple objects of the same type are "
+        "present, draw a single box that tightly encloses all of them. Do not "
+        "include any unrelated areas or background in the bounding box."
     )
-
-    # Combine the individual prompt segments into the final instruction text
     prompt_text = "\n".join(prompt_parts)
 
-    # Send the prepared prompt and image to the OpenAI API. The API
-    # will call our ``report_*`` functions if it detects any matching
-    # objects in the frame.
     response = client.chat.completions.create(
         model="gpt-4o",
         messages=[
@@ -195,50 +84,19 @@ def analyze_frame(image_path: str, look_for: str = "bare spot"):
         max_tokens=200,
     )
 
-    # Collect structured information returned via the selected tool calls
     results = []
     tool_calls = response.choices[0].message.tool_calls
     if tool_calls:
+        analyzers_by_name = {a.function_name: a for a in analyzers}
         for tool_call in tool_calls:
+            analyzer = analyzers_by_name.get(tool_call.function.name)
+            if not analyzer:
+                continue
             args = json.loads(tool_call.function.arguments)
-            # Only accept detections with reasonably high confidence
-            if tool_call.function.name == "report_bare_spot" and args.get("confidence", 0) >= 0.85:
-                results.append(
-                    {
-                        "object_type": "bare spot",
-                        "report": args["report"],
-                        "confidence": args["confidence"],
-                        "box_parameter": args.get("box_parameter"),
-                        "description": report_bare_spot(
-                            args["report"], args["confidence"], str(args.get("box_parameter"))
-                        ),
-                    }
-                )
-            elif tool_call.function.name == "report_animal" and args.get("confidence", 0) >= 0.85:
-                # Append details when an animal has been confidently detected
-                results.append(
-                    {
-                        "object_type": "animal",
-                        "species": args["species"],
-                        "description": args["description"],
-                        "confidence": args["confidence"],
-                        "box_parameter": args.get("box_parameter"),
-                    }
-                )
-            elif tool_call.function.name == "report_weed" and args.get("confidence", 0) >= 0.85:
-                results.append(
-                    {
-                        "object_type": "weed",
-                        "report": args["report"],
-                        "confidence": args["confidence"],
-                        "box_parameter": args.get("box_parameter"),
-                        "description": report_weed(
-                            args["report"], args["confidence"], str(args.get("box_parameter"))
-                        ),
-                    }
-                )
+            parsed = analyzer.parse(args)
+            if parsed:
+                results.append(parsed)
 
-    # ``None`` signals that the model did not detect anything of interest
     return results if results else None
 
 


### PR DESCRIPTION
## Summary
- introduce strategy/factory analyzers for bare spots, animals, and weeds
- refactor `analyze_frame` to use analyzers for prompt and result handling

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893adb747948331acb53ae83a1935a4